### PR TITLE
Add Canvas REST client wrapper with retry logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "node-fetch": "^2.7.0",
         "zod": "^4.1.11"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.1",
+        "@types/node-fetch": "^2.6.13",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3"
       }
@@ -170,6 +172,17 @@
         "undici-types": "~7.13.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -278,6 +291,13 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -415,6 +435,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -496,6 +529,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -586,6 +629,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -671,6 +730,46 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -811,6 +910,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1069,6 +1184,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/normalize-path": {
@@ -1530,6 +1665,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -1690,6 +1831,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "node-fetch": "^2.7.0",
     "zod": "^4.1.11"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
+    "@types/node-fetch": "^2.6.13",
     "@types/node": "^24.6.1",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.9.3"

--- a/src/lib/canvas.ts
+++ b/src/lib/canvas.ts
@@ -1,0 +1,266 @@
+import fetch, { Headers, HeadersInit, RequestInit, Response } from 'node-fetch';
+
+export interface CanvasClientOptions {
+  /** Canvas instance domain, e.g. `canvas.instructure.com`. Pulled from CANVAS_DOMAIN when omitted. */
+  domain?: string;
+  /** API access token. Pulled from CANVAS_API_TOKEN when omitted. */
+  token?: string;
+  /** Maximum number of attempts when retrying failed requests. */
+  maxAttempts?: number;
+  /** Base delay in milliseconds used when calculating exponential backoff. */
+  baseDelayMs?: number;
+}
+
+export interface CanvasCourse {
+  id: number;
+  name: string;
+  course_code: string;
+  workflow_state?: string;
+  account_id?: number;
+  term?: {
+    id: number;
+    name: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface CanvasUser {
+  id: number;
+  name: string;
+  sortable_name?: string;
+  short_name?: string;
+  login_id?: string;
+  email?: string;
+  [key: string]: unknown;
+}
+
+export interface CanvasAssignment {
+  id: number;
+  name: string;
+  description?: string;
+  due_at?: string | null;
+  points_possible?: number | null;
+  course_id?: number;
+  [key: string]: unknown;
+}
+
+export class CanvasAPIError extends Error {
+  readonly status: number;
+  readonly url: string;
+  readonly body: string;
+
+  constructor(message: string, status: number, url: string, body: string) {
+    super(message);
+    this.name = 'CanvasAPIError';
+    this.status = status;
+    this.url = url;
+    this.body = body;
+  }
+}
+
+interface InternalClientConfig {
+  baseUrl: string;
+  token: string;
+  maxAttempts: number;
+  baseDelayMs: number;
+}
+
+const API_PREFIX = '/api/v1';
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 250;
+
+function resolveBaseUrl(domain?: string): string {
+  const resolvedDomain = domain ?? process.env.CANVAS_DOMAIN;
+
+  if (!resolvedDomain) {
+    throw new Error('Canvas domain was not provided. Set CANVAS_DOMAIN or pass the domain option.');
+  }
+
+  const trimmed = resolvedDomain.trim().replace(/\/$/, '');
+  return `https://${trimmed}${API_PREFIX}`;
+}
+
+function resolveToken(token?: string): string {
+  const resolvedToken = token ?? process.env.CANVAS_API_TOKEN;
+
+  if (!resolvedToken) {
+    throw new Error(
+      'Canvas API token was not provided. Set CANVAS_API_TOKEN or pass the token option when creating the client.',
+    );
+  }
+
+  return resolvedToken.trim();
+}
+
+function createConfig(options: CanvasClientOptions = {}): InternalClientConfig {
+  return {
+    baseUrl: resolveBaseUrl(options.domain),
+    token: resolveToken(options.token),
+    maxAttempts: options.maxAttempts ?? DEFAULT_ATTEMPTS,
+    baseDelayMs: options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
+  };
+}
+
+function buildUrl(baseUrl: string, path: string): string {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return `${baseUrl}${normalized}`;
+}
+
+function parseRetryAfter(header: string | null): number | undefined {
+  if (!header) {
+    return undefined;
+  }
+
+  const seconds = Number.parseFloat(header);
+
+  if (!Number.isNaN(seconds)) {
+    return seconds * 1000;
+  }
+
+  const date = Date.parse(header);
+
+  if (!Number.isNaN(date)) {
+    const diff = date - Date.now();
+    return diff > 0 ? diff : undefined;
+  }
+
+  return undefined;
+}
+
+function createDelay(baseDelayMs: number, attempt: number, retryAfter?: number): number {
+  if (typeof retryAfter === 'number' && retryAfter > 0) {
+    return retryAfter;
+  }
+
+  const exponential = baseDelayMs * Math.pow(2, attempt - 1);
+  const jitter = Math.random() * 0.25 * exponential;
+  return exponential + jitter;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface CanvasClient {
+  listCourses(perPage?: number): Promise<CanvasCourse[]>;
+  getCourse(courseId: number | string): Promise<CanvasCourse>;
+  listCourseAssignments(courseId: number | string, perPage?: number): Promise<CanvasAssignment[]>;
+  listCourseUsers(
+    courseId: number | string,
+    options?: { enrollmentType?: string; perPage?: number },
+  ): Promise<CanvasUser[]>;
+}
+
+export function createCanvasClient(options: CanvasClientOptions = {}): CanvasClient {
+  const config = createConfig(options);
+
+  async function _fetch(path: string, init: RequestInit = {}): Promise<Response> {
+    const url = buildUrl(config.baseUrl, path);
+    const headers = new Headers(init.headers as HeadersInit | undefined);
+    headers.set('Authorization', `Bearer ${config.token}`);
+    headers.set('Accept', headers.get('Accept') ?? 'application/json');
+
+    const requestInit: RequestInit = { ...init, headers };
+
+    let lastError: Error | undefined;
+
+    for (let attempt = 1; attempt <= config.maxAttempts; attempt += 1) {
+      try {
+        const response = await fetch(url, requestInit);
+
+        if (response.ok) {
+          return response;
+        }
+
+        if (attempt < config.maxAttempts && (response.status === 429 || response.status >= 500)) {
+          const retryAfter = parseRetryAfter(response.headers.get('retry-after'));
+          const delay = createDelay(config.baseDelayMs, attempt, retryAfter);
+          await sleep(delay);
+          continue;
+        }
+
+        const body = await response.text();
+        throw new CanvasAPIError(
+          `Canvas request to ${url} failed with status ${response.status}.`,
+          response.status,
+          url,
+          body,
+        );
+      } catch (error) {
+        if (error instanceof CanvasAPIError) {
+          throw error;
+        }
+
+        lastError = error instanceof Error ? error : new Error(String(error));
+
+        if (attempt >= config.maxAttempts) {
+          const message = `Canvas request to ${url} failed after ${config.maxAttempts} attempts.`;
+          throw new CanvasAPIError(message, 0, url, lastError.message ?? '');
+        }
+
+        const delay = createDelay(config.baseDelayMs, attempt);
+        await sleep(delay);
+      }
+    }
+
+    const message = `Canvas request to ${buildUrl(config.baseUrl, path)} failed after retries.`;
+    throw new CanvasAPIError(message, 0, buildUrl(config.baseUrl, path), lastError?.message ?? '');
+  }
+
+  async function parseJson<T>(response: Response): Promise<T> {
+    const cloned = response.clone();
+
+    try {
+      return (await response.json()) as T;
+    } catch (error) {
+      const raw = await cloned.text();
+      throw new Error(
+        `Failed to parse Canvas response as JSON. Received: ${raw.substring(0, 200)}`,
+      );
+    }
+  }
+
+  return {
+    async listCourses(perPage = 10): Promise<CanvasCourse[]> {
+      const response = await _fetch(`/courses?per_page=${encodeURIComponent(perPage)}`);
+      return parseJson<CanvasCourse[]>(response);
+    },
+
+    async getCourse(courseId: number | string): Promise<CanvasCourse> {
+      const response = await _fetch(`/courses/${encodeURIComponent(courseId.toString())}`);
+      return parseJson<CanvasCourse>(response);
+    },
+
+    async listCourseAssignments(courseId: number | string, perPage = 10): Promise<CanvasAssignment[]> {
+      const response = await _fetch(
+        `/courses/${encodeURIComponent(courseId.toString())}/assignments?per_page=${encodeURIComponent(perPage)}`,
+      );
+      return parseJson<CanvasAssignment[]>(response);
+    },
+
+    async listCourseUsers(
+      courseId: number | string,
+      options?: { enrollmentType?: string; perPage?: number },
+    ): Promise<CanvasUser[]> {
+      const searchParams = new URLSearchParams();
+      const perPage = options?.perPage ?? 10;
+      searchParams.set('per_page', perPage.toString());
+
+      if (options?.enrollmentType) {
+        searchParams.set('enrollment_type[]', options.enrollmentType);
+      }
+
+      const response = await _fetch(
+        `/courses/${encodeURIComponent(courseId.toString())}/users?${searchParams.toString()}`,
+      );
+      return parseJson<CanvasUser[]>(response);
+    },
+  };
+}
+
+export const canvasClient = createCanvasClient();


### PR DESCRIPTION
## Summary
- add a Canvas REST client that injects bearer tokens and retries with exponential backoff
- expose typed helpers for courses, assignments, and users while surfacing structured errors
- add node-fetch runtime dependency and typings to support the new client

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd6997b3c8832abd52a60aa2858270