### PR TITLE
Add transport guard and rate limiting to MCP endpoints

### DIFF
--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { AddressInfo } from 'node:net';
+import test from 'node:test';
+
+import { createResultResponse } from '../lib/jsonRpc';
+import { JSONRPCDispatcher, startHttpServer } from '../transports/http';
+
+const dispatcher: JSONRPCDispatcher = async (request) =>
+  createResultResponse(request.id ?? null, { ok: true });
+
+function resolvePort(server: Awaited<ReturnType<typeof startHttpServer>>): number {
+  const address = server.address();
+  assert(address && typeof address === 'object');
+  return (address as AddressInfo).port;
+}
+
+test('POST /mcp enforces rate limiting when configured', async () => {
+  const server = await startHttpServer({
+    dispatcher,
+    host: '127.0.0.1',
+    port: 0,
+    rateLimitConfig: { windowMs: 1_000, maxRequests: 1 },
+  });
+
+  const port = resolvePort(server);
+  const url = `http://127.0.0.1:${port}/mcp`;
+  const payload = { jsonrpc: '2.0', id: 1, method: 'ping', params: {} };
+
+  try {
+    const first = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(first.status, 200);
+
+    const second = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(second.status, 429);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error?: Error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+});
+
+test('rate limiting can be bypassed for development scenarios', async () => {
+  const server = await startHttpServer({
+    dispatcher,
+    host: '127.0.0.1',
+    port: 0,
+  });
+
+  const port = resolvePort(server);
+  const url = `http://127.0.0.1:${port}/mcp`;
+  const payload = { jsonrpc: '2.0', id: 2, method: 'ping', params: {} };
+
+  try {
+    for (let i = 0; i < 3; i += 1) {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      assert.equal(response.status, 200);
+    }
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error?: Error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+});
+
+test('transport secret guard rejects missing or invalid headers', async () => {
+  const server = await startHttpServer({
+    dispatcher,
+    host: '127.0.0.1',
+    port: 0,
+    sharedSecretConfig: { secret: 'super-secret', headerName: 'x-test-secret' },
+  });
+
+  const port = resolvePort(server);
+  const url = `http://127.0.0.1:${port}/mcp`;
+  const payload = { jsonrpc: '2.0', id: 3, method: 'ping', params: {} };
+
+  try {
+    const missing = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(missing.status, 401);
+
+    const invalid = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-secret': 'wrong' },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(invalid.status, 401);
+
+    const valid = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-secret': 'super-secret' },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(valid.status, 200);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error?: Error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { logger } from './lib/logger';
-import { JSONRPCDispatcher, startHttpServer } from './transports/http';
+import {
+  JSONRPCDispatcher,
+  RateLimitConfig,
+  SharedSecretConfig,
+  startHttpServer,
+} from './transports/http';
 import { handleRpc } from './rpc';
 
 type RequiredEnvVar = 'CANVAS_DOMAIN' | 'CANVAS_API_TOKEN';
@@ -19,6 +24,44 @@ function validateRequiredEnv(): void {
     );
     process.exit(1);
   }
+}
+
+function parseBooleanEnv(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+
+  if (raw === undefined) {
+    return fallback;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+    return true;
+  }
+
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  logger.error(`${name} must be a boolean value (true/false). Received: ${raw}`);
+  process.exit(1);
+}
+
+function parsePositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+
+  if (raw === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(raw.trim(), 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    logger.error(`${name} must be set to a positive integer. Received: ${raw}`);
+    process.exit(1);
+  }
+
+  return parsed;
 }
 
 function resolvePort(rawPort: string | undefined, fallback: number): number {
@@ -59,11 +102,71 @@ async function bootstrap(): Promise<void> {
   const corsOrigins = resolveCorsOrigins();
   const corsOptions =
     corsOrigins.length === 0 || corsOrigins.includes('*') ? undefined : { origin: corsOrigins };
+  const nodeEnv = process.env.NODE_ENV?.trim().toLowerCase() ?? 'development';
+  const isProduction = nodeEnv === 'production';
+
+  const rateLimitEnabled = parseBooleanEnv('MCP_RATE_LIMIT_ENABLED', true);
+  const rateLimitBypass = parseBooleanEnv('MCP_RATE_LIMIT_BYPASS', false);
+  const rateLimitWindowMs = parsePositiveIntegerEnv('MCP_RATE_LIMIT_WINDOW_MS', 60_000);
+  const rateLimitMaxRequests = parsePositiveIntegerEnv('MCP_RATE_LIMIT_MAX_REQUESTS', 120);
+
+  let rateLimitConfig: RateLimitConfig | undefined;
+
+  if (rateLimitEnabled && !rateLimitBypass) {
+    rateLimitConfig = {
+      windowMs: rateLimitWindowMs,
+      maxRequests: rateLimitMaxRequests,
+    };
+  } else if (!rateLimitEnabled) {
+    logger.info('Per-IP rate limiting is disabled via MCP_RATE_LIMIT_ENABLED=false.');
+  } else if (rateLimitBypass) {
+    logger.info('Per-IP rate limiting bypass is enabled.');
+  }
+
+  const transportSecret = process.env.MCP_TRANSPORT_SECRET?.trim();
+  const transportSecretHeader = process.env.MCP_TRANSPORT_SECRET_HEADER?.trim() || 'x-mcp-transport-secret';
+  const transportSecretBypass = parseBooleanEnv('MCP_TRANSPORT_SECRET_BYPASS', false);
+
+  let sharedSecretConfig: SharedSecretConfig | undefined;
+
+  if (transportSecret) {
+    if (transportSecretBypass) {
+      logger.info('MCP transport secret guard is bypassed. Requests will not require a shared secret.');
+    } else {
+      sharedSecretConfig = {
+        secret: transportSecret,
+        headerName: transportSecretHeader,
+      };
+
+      if (!isProduction) {
+        logger.info(
+          `MCP transport secret guard enabled in ${nodeEnv} mode. Requests must include the ${transportSecretHeader} header.`,
+        );
+      }
+    }
+  }
+
+  if (rateLimitConfig) {
+    logger.info(
+      `Per-IP rate limiting enabled: ${rateLimitConfig.maxRequests} requests every ${rateLimitConfig.windowMs}ms.`,
+    );
+  }
+
+  if (sharedSecretConfig) {
+    logger.info(`MCP transport secret header enforcement enabled using ${transportSecretHeader}.`);
+  }
 
   try {
     // Step 3: launch the HTTP transport. Additional transports (e.g., websockets, CLI) can
     // follow this pattern by instantiating their server here and sharing the dispatcher.
-    await startHttpServer({ dispatcher, corsOptions, host, port });
+    await startHttpServer({
+      dispatcher,
+      corsOptions,
+      host,
+      port,
+      rateLimitConfig,
+      sharedSecretConfig,
+    });
   } catch (error) {
     logger.error('Fatal error while starting HTTP transport', {
       error: error instanceof Error ? { message: error.message, stack: error.stack } : error,


### PR DESCRIPTION
## Summary
- add per-IP rate limiting middleware and optional shared-secret guard to the MCP transport
- make the security features configurable via environment variables with development bypass options
- document the configuration in the README and add tests that cover rate limiting, bypass, and secret validation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd90e0ca5c832aac0ef0457a080954